### PR TITLE
Replace the `-regex` option in `_hash_find` with the `-name` one

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ $ git clone git://github.com/ShaneKilkelly/manuel-contrib-watch.git
 
 # Usage
 
-First declare an associative array called `actions`, of regex-patterns
-to watch for and corresponding actions to take when a file matching
-that pattern changes. Then call the `manuel_watch` function with a
-directory to watch over:
+First declare an associative array called `actions`,
+of [glob patterns](http://mywiki.wooledge.org/glob#Globs) to watch for
+and corresponding actions to take when a file matching that pattern
+changes. Then call the `manuel_watch` function with a directory to
+watch over:
 
 Example:
 ```bash
@@ -32,15 +33,15 @@ load_plugin manuel-contrib-watch
 function wait_for_change {
 
   declare -A actions=(
-    [".*\.js$"]="echo 'we should concat and minify the js again'"
-    [".*\.go$"]="go build ."
+    ["*?js"]="echo 'we should concat and minify the js again'"
+    ["*?go"]="go build ."
   )
 
   manuel_watch .
 }
 ```
 
-The regex patterns should be compatible with the unix `find` command.
+The glob patterns should be compatible with the unix `find` command.
 In the above example, if the file `./assets/js/app.js` changes, the first item in
 the `actions` associative-array will match, and the corresponding command
 string will be run.

--- a/manuel-contrib-watch.manuel
+++ b/manuel-contrib-watch.manuel
@@ -36,11 +36,11 @@ function _get_md5_command {
 # hash the results of a find
 function _hash_find {
   search_dir=$1
-  regex_pattern=$2
+  glob_pattern=$2
   md5_command=$(_get_md5_command)
 
   result=$(
-    find "$search_dir" -regex "$regex_pattern" -printf '%Tc %p\n' | $md5_command
+    find "$search_dir" -name "$glob_pattern" -printf '%Tc %p\n' | $md5_command
   )
 
   echo "$result"


### PR DESCRIPTION
* This way we can use [bash glog patterns](http://mywiki.wooledge.org/glob#Globs) instead of the regex patterns.